### PR TITLE
Add standardized issue templates and enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a problem or unexpected behavior in WorkSight
+labels: bug
+---
+
+## Who are you?
+- [ ] Employee
+- [ ] Manager
+- [ ] HR/People Ops
+- [ ] IT/Data Team
+- [ ] Other: __________
+
+## Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+1. 
+2. 
+3. 
+
+## Expected behavior
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+<!-- What actually happened? -->
+
+## Screenshots or logs
+<!-- If applicable, add screenshots or error logs to help explain your problem. -->
+
+## Impact
+<!-- How does this bug affect your work or your team? -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/data_integration_issue.md
+++ b/.github/ISSUE_TEMPLATE/data_integration_issue.md
@@ -1,0 +1,22 @@
+---
+name: Data Integration Issue
+about: Report problems with data sources, integrations, or syncing
+labels: data, integration
+---
+
+## System or integration affected
+<!-- e.g., HRIS, Task Management, Attendance, etc. -->
+
+## Describe the issue
+<!-- What is not working as expected? -->
+
+## Steps to reproduce or observe
+1. 
+2. 
+3. 
+
+## Impact
+<!-- How does this affect data accuracy, dashboards, or user experience? -->
+
+## Additional context
+<!-- Logs, screenshots, or error messages if available. -->

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,17 @@
+---
+name: Documentation Request
+about: Request improvements or additions to documentation
+labels: documentation
+---
+
+## What needs documentation?
+<!-- Describe the page, section, or feature that needs documentation. -->
+
+## What information is missing or unclear?
+<!-- Be specific about what is lacking or confusing. -->
+
+## Suggested improvements
+<!-- If you have suggestions for how to improve the docs, add them here. -->
+
+## Additional context
+<!-- Add any other context, links, or screenshots here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for WorkSight
+labels: enhancement
+---
+
+## Who are you?
+- [ ] Employee
+- [ ] Manager
+- [ ] HR/People Ops
+- [ ] IT/Data Team
+- [ ] Other: __________
+
+## Describe the feature or improvement
+<!-- A clear and concise description of what you want to happen. -->
+
+## What problem does this solve?
+<!-- Explain how this feature will help you or your team. -->
+
+## Additional context
+<!-- Add any other context, screenshots, or examples here. -->

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,18 @@
+---
+name: General Feedback
+about: Share feedback, suggestions, or questions about WorkSight
+labels: feedback
+---
+
+## Who are you?
+- [ ] Employee
+- [ ] Manager
+- [ ] HR/People Ops
+- [ ] IT/Data Team
+- [ ] Other: __________
+
+## Your feedback
+<!-- Share your thoughts, suggestions, or questions here. -->
+
+## Area of the platform
+<!-- e.g., Dashboard, Notifications, Data Integration, etc. -->

--- a/.github/ISSUE_TEMPLATE/privacy_security_concern.md
+++ b/.github/ISSUE_TEMPLATE/privacy_security_concern.md
@@ -1,0 +1,23 @@
+---
+name: Privacy/Security Concern
+about: Report a privacy or security issue related to WorkSight
+labels: security, privacy
+---
+
+## Describe the concern
+<!-- What privacy or security issue have you observed? -->
+
+## Area affected
+- [ ] Employee data
+- [ ] Manager/Team data
+- [ ] External integrations
+- [ ] Other: __________
+
+## Steps to reproduce or details
+<!-- How did you notice this? Any steps to reproduce? -->
+
+## Potential impact
+<!-- What risks or consequences could this cause? -->
+
+## Suggested mitigation (if any)
+<!-- Any ideas for how this could be addressed? -->


### PR DESCRIPTION
### Summary

- Added standardized issue templates for bug reports, feature requests, documentation requests, and data integration issues.
- Enabled blank issues in `.github/ISSUE_TEMPLATE/config.yml` for flexibility.

### Details

- Ensures contributors provide consistent and complete information when reporting issues or requesting features.
- Allows users to submit custom issues if none of the templates fit their needs.

### Checklist

- [x] Issue templates appear and are selectable when creating a new issue
- [x] Blank issue option is available
- [x] All templates and config tested on